### PR TITLE
dont error at deleted secrets

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,7 +36,7 @@ nfpms:
       - vkv
     vendor: FalcoSuessgott
     homepage:  https://github.com/FalcoSuessgott/vkv
-    maintainer: "Tom Morelly <tom-morelly@gmx.de"
+    maintainer: "Tom Morelly <tom-morelly@gmx.de>"
     description: "recursively list secrets from Vaults KV2 engine in various formats"
     license: GPL-3.0
     formats:

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -81,7 +81,9 @@ func (s *Secrets) ListRecursive(v *Vault, rootPath, subPath string) error {
 		} else {
 			secrets, err := v.ReadSecrets(rootPath, path.Join(subPath, k))
 			if err != nil {
-				return err
+				(*s)[path.Join(rootPath, subPath, k)] = map[string]interface{}{}
+
+				continue
 			}
 
 			(*s)[path.Join(rootPath, subPath, k)] = secrets


### PR DESCRIPTION
This PR fixes a bug were `vkv` would end with an error if a deleted secrets returns `null`.

fixes #62 