### PR TITLE
feat(printer): introduce printer interface

### DIFF
--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/FalcoSuessgott/vkv/pkg/fs"
-	printer "github.com/FalcoSuessgott/vkv/pkg/printer/secret"
+	prt "github.com/FalcoSuessgott/vkv/pkg/printer/secret"
 )
 
 func (s *VaultSuite) TestValidateExportFlags() {
@@ -121,45 +121,45 @@ func (s *VaultSuite) TestExportImportCommand() {
 func (s *VaultSuite) TestExportOutputFormat() {
 	testCases := []struct {
 		name     string
-		expected printer.OutputFormat
+		expected prt.OutputFormat
 		err      bool
 	}{
 		{
 			name:     "json",
-			expected: printer.JSON,
+			expected: prt.JSON,
 		},
 		{
 			name:     "yaml",
-			expected: printer.YAML,
+			expected: prt.YAML,
 		},
 		{
 			name:     "yml",
-			expected: printer.YAML,
+			expected: prt.YAML,
 		},
 		{
 			name:     "invalid",
 			err:      true,
-			expected: printer.YAML,
+			expected: prt.YAML,
 		},
 		{
 			name:     "export",
-			expected: printer.Export,
+			expected: prt.Export,
 		},
 		{
 			name:     "markdown",
-			expected: printer.Markdown,
+			expected: prt.Markdown,
 		},
 		{
 			name:     "base",
-			expected: printer.Base,
+			expected: prt.Base,
 		},
 		{
 			name:     "template",
-			expected: printer.Template,
+			expected: prt.Template,
 		},
 		{
 			name:     "tmpl",
-			expected: printer.Template,
+			expected: prt.Template,
 		},
 	}
 

--- a/cmd/list_engines_test.go
+++ b/cmd/list_engines_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"io"
 
-	printer "github.com/FalcoSuessgott/vkv/pkg/printer/engine"
+	prt "github.com/FalcoSuessgott/vkv/pkg/printer/engine"
 	"github.com/FalcoSuessgott/vkv/pkg/vault"
 )
 
@@ -70,29 +70,29 @@ secret_2/
 func (s *VaultSuite) TestEnginesOutputFormat() {
 	testCases := []struct {
 		name     string
-		expected printer.OutputFormat
+		expected prt.OutputFormat
 		err      bool
 	}{
 		{
 			name:     "json",
-			expected: printer.JSON,
+			expected: prt.JSON,
 		},
 		{
 			name:     "yaml",
-			expected: printer.YAML,
+			expected: prt.YAML,
 		},
 		{
 			name:     "yml",
-			expected: printer.YAML,
+			expected: prt.YAML,
 		},
 		{
 			name:     "invalid",
 			err:      true,
-			expected: printer.YAML,
+			expected: prt.YAML,
 		},
 		{
 			name:     "base",
-			expected: printer.Base,
+			expected: prt.Base,
 		},
 	}
 

--- a/cmd/list_namespace.go
+++ b/cmd/list_namespace.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"strings"
 
-	printer "github.com/FalcoSuessgott/vkv/pkg/printer/namespace"
+	prt "github.com/FalcoSuessgott/vkv/pkg/printer/namespace"
 	"github.com/FalcoSuessgott/vkv/pkg/utils"
 	"github.com/FalcoSuessgott/vkv/pkg/vault"
 	"github.com/spf13/cobra"
@@ -19,7 +19,7 @@ type listNamespaceOptions struct {
 	All          bool   `env:"ALL"`
 	FormatString string `env:"FORMAT" envDefault:"base"`
 
-	outputFormat printer.OutputFormat
+	outputFormat prt.OutputFormat
 }
 
 func newListNamespacesCmd() *cobra.Command {
@@ -55,10 +55,10 @@ func newListNamespacesCmd() *cobra.Command {
 				}
 			}
 
-			return printer.NewPrinter(
-				printer.ToFormat(o.outputFormat),
-				printer.WithWriter(writer),
-				printer.WithRegex(o.Regex),
+			return prt.NewNamespacePrinter(
+				prt.ToFormat(o.outputFormat),
+				prt.WithWriter(writer),
+				prt.WithRegex(o.Regex),
 			).Out(namespaces)
 		},
 	}
@@ -76,13 +76,13 @@ func newListNamespacesCmd() *cobra.Command {
 func (o *listNamespaceOptions) Validate() error {
 	switch strings.ToLower(o.FormatString) {
 	case "yaml", "yml":
-		o.outputFormat = printer.YAML
+		o.outputFormat = prt.YAML
 	case "json":
-		o.outputFormat = printer.JSON
+		o.outputFormat = prt.JSON
 	case "base":
-		o.outputFormat = printer.Base
+		o.outputFormat = prt.Base
 	default:
-		return printer.ErrInvalidFormat
+		return prt.ErrInvalidFormat
 	}
 
 	return nil

--- a/cmd/list_namespaces_test.go
+++ b/cmd/list_namespaces_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	printer "github.com/FalcoSuessgott/vkv/pkg/printer/namespace"
+	prt "github.com/FalcoSuessgott/vkv/pkg/printer/namespace"
 	"github.com/FalcoSuessgott/vkv/pkg/utils"
 	"github.com/FalcoSuessgott/vkv/pkg/vault"
 	"github.com/stretchr/testify/assert"
@@ -78,38 +78,38 @@ func TestNamespaceOutputFormat(t *testing.T) {
 	testCases := []struct {
 		name     string
 		format   string
-		expected printer.OutputFormat
+		expected prt.OutputFormat
 		err      bool
 	}{
 		{
 			name:     "json",
 			err:      false,
 			format:   "json",
-			expected: printer.JSON,
+			expected: prt.JSON,
 		},
 		{
 			name:     "yaml",
 			err:      false,
 			format:   "YamL",
-			expected: printer.YAML,
+			expected: prt.YAML,
 		},
 		{
 			name:     "yml",
 			err:      false,
 			format:   "yml",
-			expected: printer.YAML,
+			expected: prt.YAML,
 		},
 		{
 			name:     "invalid",
 			err:      true,
 			format:   "invalid",
-			expected: printer.YAML,
+			expected: prt.YAML,
 		},
 		{
 			name:     "base",
 			err:      false,
 			format:   "base",
-			expected: printer.Base,
+			expected: prt.Base,
 		},
 	}
 
@@ -121,7 +121,7 @@ func TestNamespaceOutputFormat(t *testing.T) {
 		err := o.Validate()
 
 		if tc.err {
-			require.ErrorIs(t, err, printer.ErrInvalidFormat, tc.name)
+			require.ErrorIs(t, err, prt.ErrInvalidFormat, tc.name)
 		} else {
 			require.NoError(t, err, tc.name, tc.name)
 			assert.Equal(t, tc.expected, o.outputFormat, tc.name)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	prt "github.com/FalcoSuessgott/vkv/pkg/printer"
 	"github.com/FalcoSuessgott/vkv/pkg/vault"
 	"github.com/spf13/cobra"
 )
@@ -28,6 +29,8 @@ var (
 	errInvalidFlagCombination = errors.New("invalid flag combination specified")
 	vaultClient               *vault.Vault
 	writer                    io.Writer
+
+	printer prt.Printer
 )
 
 // NewRootCmd vkv root command.

--- a/cmd/snapshot_save.go
+++ b/cmd/snapshot_save.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/FalcoSuessgott/vkv/pkg/fs"
-	printer "github.com/FalcoSuessgott/vkv/pkg/printer/secret"
+	prt "github.com/FalcoSuessgott/vkv/pkg/printer/secret"
 	"github.com/FalcoSuessgott/vkv/pkg/utils"
 	"github.com/FalcoSuessgott/vkv/pkg/vault"
 	"github.com/spf13/cobra"
@@ -72,17 +72,18 @@ func (o *snapshotSaveOptions) backupKVEngines(v *vault.Vault, engines map[string
 
 			b := bytes.NewBufferString("")
 
-			p := printer.NewPrinter(
-				printer.CustomValueLength(-1),
-				printer.ShowValues(true),
-				printer.ToFormat(printer.JSON),
-				printer.WithVaultClient(v),
-				printer.WithWriter(b),
-				printer.ShowVersion(false),
-				printer.ShowMetadata(false),
+			printer = prt.NewSecretPrinter(
+				prt.CustomValueLength(-1),
+				prt.ShowValues(true),
+				prt.ToFormat(prt.JSON),
+				prt.WithVaultClient(v),
+				prt.WithWriter(b),
+				prt.ShowVersion(false),
+				prt.ShowMetadata(false),
+				prt.WithEnginePath(strings.TrimSuffix(e, utils.Delimiter)),
 			)
 
-			if err := p.Out(strings.TrimSuffix(e, utils.Delimiter), utils.ToMapStringInterface(out)); err != nil {
+			if err := printer.Out(utils.ToMapStringInterface(out)); err != nil {
 				return err
 			}
 

--- a/pkg/printer/engine/engine_printer_test.go
+++ b/pkg/printer/engine/engine_printer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/FalcoSuessgott/vkv/pkg/vault"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -11,7 +12,7 @@ import (
 func TestPrintEngines(t *testing.T) {
 	testCases := []struct {
 		name     string
-		ns       map[string][]string
+		ns       vault.Engines
 		opts     []Option
 		expected string
 		err      bool
@@ -130,7 +131,7 @@ p/b
 
 		tc.opts = append(tc.opts, WithWriter(&b))
 
-		p := NewPrinter(tc.opts...)
+		p := NewEnginePrinter(tc.opts...)
 
 		err := p.Out(tc.ns)
 

--- a/pkg/printer/namespace/namespace_printer_test.go
+++ b/pkg/printer/namespace/namespace_printer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/FalcoSuessgott/vkv/pkg/vault"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -11,7 +12,7 @@ import (
 func TestPrintNamespaces(t *testing.T) {
 	testCases := []struct {
 		name     string
-		ns       map[string][]string
+		ns       vault.Namespaces
 		opts     []Option
 		expected string
 		err      bool
@@ -126,13 +127,14 @@ a/a2
 
 		tc.opts = append(tc.opts, WithWriter(&b))
 
-		p := NewPrinter(tc.opts...)
+		p := NewNamespacePrinter(tc.opts...)
 
 		err := p.Out(tc.ns)
 
 		if tc.err {
-			require.Error(t, err)
+			require.Error(t, err, tc.name)
 		} else {
+			require.NoError(t, err, tc.name)
 			assert.Equal(t, tc.expected, b.String(), tc.name)
 		}
 	}

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -1,0 +1,7 @@
+package printer
+
+// Printer prints the entities (for now ns, engines and KV secrets).
+type Printer interface {
+	// Out prints out the entities.
+	Out(secrets interface{}) error
+}

--- a/pkg/printer/secret/base.go
+++ b/pkg/printer/secret/base.go
@@ -11,29 +11,29 @@ import (
 	"github.com/xlab/treeprint"
 )
 
-func (p *Printer) printBase(enginePath string, secrets map[string]interface{}) error {
+func (p *Printer) printBase(secrets map[string]interface{}) error {
 	var tree treeprint.Tree
 
 	m := make(map[string]interface{})
 
 	for _, k := range utils.SortMapKeys(secrets) {
-		baseName := enginePath + utils.Delimiter
+		baseName := p.enginePath + utils.Delimiter
 
 		if p.withHyperLinks {
-			addr := fmt.Sprintf("%s/ui/vault/secrets/%s/kv", p.vaultClient.Client.Address(), enginePath)
+			addr := fmt.Sprintf("%s/ui/vault/secrets/%s/kv", p.vaultClient.Client.Address(), p.enginePath)
 
-			baseName = termlink.Link(enginePath+utils.Delimiter, addr, false)
+			baseName = termlink.Link(p.enginePath+utils.Delimiter, addr, false)
 		}
 
 		if p.vaultClient != nil {
 			// append description
-			desc, err := p.vaultClient.GetEngineDescription(enginePath)
+			desc, err := p.vaultClient.GetEngineDescription(p.enginePath)
 			if err == nil && desc != "" {
 				baseName = fmt.Sprintf("%s [desc=%s]", baseName, desc)
 			}
 
 			// append type + version
-			engineType, version, err := p.vaultClient.GetEngineTypeVersion(enginePath)
+			engineType, version, err := p.vaultClient.GetEngineTypeVersion(p.enginePath)
 			if err == nil {
 				baseName = fmt.Sprintf("%s [type=%s]", baseName, engineType+version)
 			}
@@ -46,7 +46,7 @@ func (p *Printer) printBase(enginePath string, secrets map[string]interface{}) e
 
 	for _, i := range utils.SortMapKeys(m) {
 		//nolint: forcetypeassert
-		tree.AddBranch(p.printTree(enginePath, i, m[i].(map[string]interface{})))
+		tree.AddBranch(p.printTree(p.enginePath, i, m[i].(map[string]interface{})))
 	}
 
 	fmt.Fprintln(p.writer, strings.TrimSpace(tree.String()))

--- a/pkg/printer/secret/base_test.go
+++ b/pkg/printer/secret/base_test.go
@@ -114,14 +114,17 @@ func TestPrintBase(t *testing.T) {
 
 	for _, tc := range testCases {
 		var b bytes.Buffer
-		tc.opts = append(tc.opts, WithWriter(&b))
+		tc.opts = append(tc.opts,
+			WithWriter(&b),
+			WithEnginePath(tc.rootPath),
+		)
 
-		p := NewPrinter(tc.opts...)
+		p := NewSecretPrinter(tc.opts...)
 
 		m := map[string]interface{}{}
 
 		m[tc.rootPath+"/"] = tc.s
-		require.NoError(t, p.Out(tc.rootPath, m))
+		require.NoError(t, p.Out(m))
 		assert.Equal(t, tc.output, b.String(), tc.name)
 	}
 }

--- a/pkg/printer/secret/export_test.go
+++ b/pkg/printer/secret/export_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/FalcoSuessgott/vkv/pkg/vault"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -11,7 +12,7 @@ import (
 func TestPrintExport(t *testing.T) {
 	testCases := []struct {
 		name     string
-		s        map[string]interface{}
+		s        vault.Secrets
 		rootPath string
 		opts     []Option
 		output   string
@@ -48,12 +49,12 @@ export user='password'
 		var b bytes.Buffer
 		tc.opts = append(tc.opts, WithWriter(&b))
 
-		p := NewPrinter(tc.opts...)
+		p := NewSecretPrinter(tc.opts...)
 
 		m := map[string]interface{}{}
 
 		m[tc.rootPath+"/"] = tc.s
-		require.NoError(t, p.Out(tc.rootPath, m))
+		require.NoError(t, p.Out(m))
 		assert.Equal(t, tc.output, b.String(), tc.name)
 	}
 }

--- a/pkg/printer/secret/helpers_test.go
+++ b/pkg/printer/secret/helpers_test.go
@@ -3,6 +3,7 @@ package secret
 import (
 	"testing"
 
+	"github.com/FalcoSuessgott/vkv/pkg/vault"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -10,8 +11,8 @@ func TestMaskSecrets(t *testing.T) {
 	testCases := []struct {
 		name    string
 		options []Option
-		input   map[string]interface{}
-		output  map[string]interface{}
+		input   vault.Secrets
+		output  vault.Secrets
 	}{
 		{
 			name:    "test: normal secrets",
@@ -46,7 +47,7 @@ func TestMaskSecrets(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		p := NewPrinter(tc.options...)
+		p := NewSecretPrinter(tc.options...)
 
 		p.maskValues(tc.input)
 

--- a/pkg/printer/secret/json_test.go
+++ b/pkg/printer/secret/json_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/FalcoSuessgott/vkv/pkg/vault"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -11,7 +12,7 @@ import (
 func TestPrintJSON(t *testing.T) {
 	testCases := []struct {
 		name     string
-		s        map[string]interface{}
+		s        vault.Secrets
 		rootPath string
 		opts     []Option
 		output   string
@@ -69,12 +70,12 @@ func TestPrintJSON(t *testing.T) {
 		var b bytes.Buffer
 		tc.opts = append(tc.opts, WithWriter(&b))
 
-		p := NewPrinter(tc.opts...)
+		p := NewSecretPrinter(tc.opts...)
 
 		m := map[string]interface{}{}
 
 		m[tc.rootPath+"/"] = tc.s
-		require.NoError(t, p.Out(tc.rootPath, m))
+		require.NoError(t, p.Out(m))
 		assert.Equal(t, tc.output, b.String(), tc.name)
 	}
 }

--- a/pkg/printer/secret/markdown.go
+++ b/pkg/printer/secret/markdown.go
@@ -8,8 +8,8 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
-func (p *Printer) printMarkdownTable(enginePath string, secrets map[string]interface{}) error {
-	headers, data := p.buildMarkdownTable(enginePath, secrets)
+func (p *Printer) printMarkdownTable(secrets map[string]interface{}) error {
+	headers, data := p.buildMarkdownTable(secrets)
 
 	table := tablewriter.NewWriter(p.writer)
 	table.SetHeader(headers)
@@ -23,7 +23,7 @@ func (p *Printer) printMarkdownTable(enginePath string, secrets map[string]inter
 }
 
 // nolint: gocognit, nestif, cyclop
-func (p *Printer) buildMarkdownTable(enginePath string, secrets map[string]interface{}) ([]string, [][]string) {
+func (p *Printer) buildMarkdownTable(secrets map[string]interface{}) ([]string, [][]string) {
 	data := [][]string{}
 	headers := []string{}
 
@@ -47,7 +47,7 @@ func (p *Printer) buildMarkdownTable(enginePath string, secrets map[string]inter
 		default:
 			headers = []string{"path", "key", "value"}
 
-			rootPath := enginePath
+			rootPath := p.enginePath
 			subPath := strings.ReplaceAll(k, rootPath, "")
 
 			for i, j := range utils.SortMapKeys(v) {

--- a/pkg/printer/secret/markdown_test.go
+++ b/pkg/printer/secret/markdown_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/FalcoSuessgott/vkv/pkg/vault"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -11,7 +12,7 @@ import (
 func TestPrintMarkdown(t *testing.T) {
 	testCases := []struct {
 		name     string
-		s        map[string]interface{}
+		s        vault.Secrets
 		rootPath string
 		opts     []Option
 		output   string
@@ -78,12 +79,12 @@ func TestPrintMarkdown(t *testing.T) {
 		var b bytes.Buffer
 		tc.opts = append(tc.opts, WithWriter(&b))
 
-		p := NewPrinter(tc.opts...)
+		p := NewSecretPrinter(tc.opts...)
 
 		m := map[string]interface{}{}
 
 		m[tc.rootPath+"/"] = tc.s
-		require.NoError(t, p.Out(tc.rootPath, m))
+		require.NoError(t, p.Out(m))
 		assert.Equal(t, tc.output, b.String(), tc.name)
 	}
 }
@@ -141,8 +142,8 @@ func TestMarkdownHeader(t *testing.T) {
 		m := map[string]interface{}{}
 		m["root"] = tc.s
 
-		p := NewPrinter(tc.opts...)
-		headers, _ := p.buildMarkdownTable("", m)
+		p := NewSecretPrinter(tc.opts...)
+		headers, _ := p.buildMarkdownTable(m)
 
 		assert.Equal(t, tc.expected, headers, tc.name)
 	}

--- a/pkg/printer/secret/policy_test.go
+++ b/pkg/printer/secret/policy_test.go
@@ -36,7 +36,7 @@ func TestPrintPolicy(t *testing.T) {
 		var b bytes.Buffer
 		tc.opts = append(tc.opts, WithWriter(&b))
 
-		p := NewPrinter(tc.opts...)
+		p := NewSecretPrinter(tc.opts...)
 
 		require.NoError(t, p.printCapabilities(tc.caps))
 

--- a/pkg/printer/secret/template_test.go
+++ b/pkg/printer/secret/template_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/FalcoSuessgott/vkv/pkg/utils"
+	"github.com/FalcoSuessgott/vkv/pkg/vault"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -12,7 +13,7 @@ import (
 func TestPrintTemplate(t *testing.T) {
 	testCases := []struct {
 		name     string
-		s        map[string]interface{}
+		s        vault.Secrets
 		rootPath string
 		opts     []Option
 		output   string
@@ -83,12 +84,12 @@ path "root/secret/*" {
 		var b bytes.Buffer
 		tc.opts = append(tc.opts, WithWriter(&b))
 
-		p := NewPrinter(tc.opts...)
+		p := NewSecretPrinter(tc.opts...)
 
 		m := map[string]interface{}{}
 
 		m[tc.rootPath+"/"] = tc.s
-		require.NoError(t, p.Out(tc.rootPath, m))
+		require.NoError(t, p.Out(m))
 		assert.Equal(t, tc.output, utils.RemoveCarriageReturns(b.String()), tc.name)
 	}
 }

--- a/pkg/printer/secret/yaml_test.go
+++ b/pkg/printer/secret/yaml_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/FalcoSuessgott/vkv/pkg/vault"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -11,7 +12,7 @@ import (
 func TestPrintYAML(t *testing.T) {
 	testCases := []struct {
 		name     string
-		s        map[string]interface{}
+		s        vault.Secrets
 		rootPath string
 		opts     []Option
 		output   string
@@ -63,12 +64,12 @@ func TestPrintYAML(t *testing.T) {
 		var b bytes.Buffer
 		tc.opts = append(tc.opts, WithWriter(&b))
 
-		p := NewPrinter(tc.opts...)
+		p := NewSecretPrinter(tc.opts...)
 
 		m := map[string]interface{}{}
 
 		m[tc.rootPath+"/"] = tc.s
-		require.NoError(t, p.Out(tc.rootPath, m))
+		require.NoError(t, p.Out(m))
 		assert.Equal(t, tc.output, b.String(), tc.name)
 	}
 }

--- a/pkg/vault/capability_test.go
+++ b/pkg/vault/capability_test.go
@@ -12,7 +12,7 @@ func (s *VaultSuite) TestGetCapabilities() {
 		name     string
 		rootPath string
 		subPath  string
-		s        map[string]interface{}
+		s        Secrets
 		expected *Capability
 	}{
 		{


### PR DESCRIPTION
package printer now exposes a `Printer` interface that requires a `Out(interface{}) error` method to be implemented. the secret, engines and namespace package satify that now