### PR TITLE
feat(export): add --export-upper and --export-include-path options

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -27,6 +27,9 @@ type exportOptions struct {
 
 	SkipErrors bool `env:"SKIP_ERRORS" envDefault:"false"`
 
+	ExportIncludePath bool `env:"EXPORT_INCLUDE_PATH"`
+	ExportUpper       bool `env:"EXPORT_UPPER"`
+
 	TemplateFile   string `env:"TEMPLATE_FILE"`
 	TemplateString string `env:"TEMPLATE_STRING"`
 
@@ -55,18 +58,20 @@ func NewExportCmd() *cobra.Command {
 			enginePath, _ := utils.HandleEnginePath(o.EnginePath, o.Path)
 
 			printer = prt.NewSecretPrinter(
+				prt.WithEnginePath(enginePath),
 				prt.OnlyKeys(o.OnlyKeys),
 				prt.OnlyPaths(o.OnlyPaths),
 				prt.CustomValueLength(o.MaxValueLength),
 				prt.ShowValues(o.ShowValues),
-				prt.WithTemplate(o.TemplateString, o.TemplateFile),
 				prt.ToFormat(o.outputFormat),
 				prt.WithVaultClient(vaultClient),
 				prt.WithWriter(writer),
 				prt.ShowVersion(o.ShowVersion),
 				prt.ShowMetadata(o.ShowMetadata),
 				prt.WithHyperLinks(o.WithHyperLink),
-				prt.WithEnginePath(enginePath),
+				prt.WithTemplate(o.TemplateString, o.TemplateFile),
+				prt.WithExportIncludePath(o.ExportIncludePath),
+				prt.WithExportUpper(o.ExportUpper),
 			)
 
 			// prepare map
@@ -100,6 +105,10 @@ func NewExportCmd() *cobra.Command {
 
 	cmd.Flags().IntVar(&o.MaxValueLength, "max-value-length", o.MaxValueLength, "maximum char length of values. Set to \"-1\" for disabling "+
 		"(env: VKV_EXPORT_MAX_VALUE_LENGTH)")
+
+	// Export
+	cmd.Flags().BoolVar(&o.ExportIncludePath, "export-include-path", o.ExportIncludePath, "include the secret path as the env var prefix in format export (env: VKV_EXPORT_EXPORT_INCLUDE_PATH)")
+	cmd.Flags().BoolVar(&o.ExportUpper, "export-upper", o.ExportUpper, "upper case the env var names (env: VKV_EXPORT_UPPER)")
 
 	// Template
 	cmd.Flags().StringVar(&o.TemplateFile, "template-file", o.TemplateFile, "path to a file containing Go-template syntax to render the KV entries (env: VKV_EXPORT_TEMPLATE_FILE)")

--- a/docs/example_direnv.md
+++ b/docs/example_direnv.md
@@ -7,18 +7,37 @@ You can use `vkv` and [`direnv`](https://direnv.net/) to autimatically source KV
 ## Demo
 
 Create in a project a `.envrc` file:
-```bash
-export VAULT_ADDR="https://vault:8200"
-export VAULT_TOKEN="$(cat ~/.vault-token)"
 
-eval $(vkv export -p kv/secrets -f export)
+```bash
+> export VAULT_ADDR="https://vault:8200"
+> export VAULT_TOKEN="$(cat ~/.vault-token)"
+> eval $(vkv export -p kv/secrets -f export)
 ```
 
 Now if you go into that directory and run `direnv allow`, 
 you have the secrets under `kv/secrets` exported as env various:
 
 ```bash
-env | grep OS_
+> env | grep OS_
 OS_USER=admin
 OS_PASSWORD=pasword
+```
+
+## Upper Case the env var keys
+`--export-upper` will upper-case all env var keys:
+
+```bash
+> vkv export -p secret/sub/demo -f export --export-upper
+export DEMO='hello world'
+export PASSWORD='s3cre5<'
+```
+
+## Include paths as env var key prefix
+`--export-include-path` will prefix the secrets path and use `_` as the delimiter:
+
+```bash
+> vkv export -p secret/sub/demo -f export --export-upper --export-include-path
+export SECRET_SUB_DEMO_DEMO='hello world'
+export SECRET_SUB_DEMO_PASSWORD='s3cre5<'
+export SECRET_SUB_DEMO_USER='admin'
 ```

--- a/pkg/printer/secret/export_test.go
+++ b/pkg/printer/secret/export_test.go
@@ -43,6 +43,40 @@ export user='password'
 			},
 			output: "",
 		},
+		{
+			name: "upper",
+			s: map[string]interface{}{
+				"secret": map[string]interface{}{
+					"key":  "value",
+					"user": "password",
+				},
+			}, opts: []Option{
+				ToFormat(Export),
+				ShowValues(true),
+				WithExportUpper(true),
+			},
+			output: `export KEY='value'
+export USER='password'
+`,
+		},
+		{
+			name:     "include path",
+			rootPath: "root",
+			s: map[string]interface{}{
+				"secret": map[string]interface{}{
+					"key":  "value",
+					"user": "password",
+				},
+			}, opts: []Option{
+				ToFormat(Export),
+				ShowValues(true),
+				WithExportUpper(true),
+				WithExportIncludePath(true),
+			},
+			output: `export ROOT_SECRET_KEY='value'
+export ROOT_SECRET_USER='password'
+`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/printer/secret/secret_printer.go
+++ b/pkg/printer/secret/secret_printer.go
@@ -65,8 +65,13 @@ type Printer struct {
 	showMetadata   bool
 	withHyperLinks bool
 	valueLength    int
-	template       string
-	vaultClient    *vault.Vault
+
+	template string
+
+	includePath bool
+	upper       bool
+
+	vaultClient *vault.Vault
 }
 
 // CustomValueLength option for trimming down the output of secrets.
@@ -163,6 +168,20 @@ func WithTemplate(str, path string) Option {
 
 			return
 		}
+	}
+}
+
+// WithExportUpper sets the export keys to uppercase.
+func WithExportUpper(b bool) Option {
+	return func(p *Printer) {
+		p.upper = b
+	}
+}
+
+// WithExportIncludePath sets the export keys to include the path.
+func WithExportIncludePath(b bool) Option {
+	return func(p *Printer) {
+		p.includePath = b
 	}
 }
 


### PR DESCRIPTION
 fixes #270 
 
Adds the following options to `vkv export`:

`--export-upper` will upper-case all env var keys:

```bash
> vkv export -p secret/sub/demo -f export --export-upper
export DEMO='hello world'
export PASSWORD='s3cre5<'
```

`--export-include-path` will prefix the secrets path and use `_` as the delimiter:

```bash
> vkv export -p secret/sub/demo -f export --export-upper --export-include-path
export SECRET_SUB_DEMO_DEMO='hello world'
export SECRET_SUB_DEMO_PASSWORD='s3cre5<'
export SECRET_SUB_DEMO_USER='admin'
```