### PR TITLE
fix: skip vault client for help and version commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,8 +43,8 @@ func NewRootCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			// skip vault client creation for completion, docs and manpage generation
-			if (cmd.HasParent() && cmd.Parent().Use == "completion") || cmd.Use == "docs" || cmd.Use == "man" {
+			// skip vault client creation for completion, version, help, docs and manpage generation
+			if (cmd.HasParent() && cmd.Parent().Use == "completion") || cmd.Use == "docs" || cmd.Use == "help" || cmd.Use == "version" || cmd.Use == "man" {
 				return nil
 			}
 


### PR DESCRIPTION
Since version 0.6.4 (I think), the `version` and `help` commands require authentication on a vault server:
```
$ vkv version
[ERROR] not authenticated, perhaps not a valid token: Get "https://127.0.0.1:8200/v1/auth/token/lookup-self": dial tcp 127.0.0.1:8200: connect: connection refused.
$ vkv help
[ERROR] not authenticated, perhaps not a valid token: Get "https://127.0.0.1:8200/v1/auth/token/lookup-self": dial tcp 127.0.0.1:8200: connect: connection refused.
```
It's confusing when you're new to `vkv`. And even when you know the tool already, it's sometimes annoying (I use `vkv` in some scripts where I'd like to display/check the tool version before I set up the required env vars for vault authentication).

This PR should fix that.