### PR TITLE
feat(import): support engine path

### DIFF
--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -20,19 +20,22 @@ func (s *VaultSuite) TestValidateImportFlags() {
 			err:  true,
 		},
 		{
-			name: "no path should fail",
-			err:  true,
-			args: []string{},
-		},
-		{
 			name: "silent and dry-run should fail",
 			err:  true,
 			args: []string{"-p=o", "-s", "-d"},
+		},
+		{
+			name: "file and STDIN should fail",
+			err:  true,
+			args: []string{"-f=sss", "-"},
 		},
 	}
 
 	for _, tc := range testCases {
 		cmd := NewImportCmd()
+
+		writer = io.Discard
+
 		cmd.SetArgs(tc.args)
 
 		err := cmd.Execute()
@@ -62,7 +65,6 @@ func (s *VaultSuite) TestGetInput() {
 			expected: `yaml/:
   secret:
     user: password
-
 `,
 		},
 		{

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -75,8 +75,6 @@ func (o *serverOptions) validateFlags(cmd *cobra.Command, args []string) error {
 }
 
 func (o *serverOptions) buildMap() (map[string]interface{}, error) {
-	var isSecretPath bool
-
 	rootPath, subPath := utils.HandleEnginePath(o.EnginePath, o.Path)
 
 	// read recursive all secrets
@@ -85,18 +83,13 @@ func (o *serverOptions) buildMap() (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	// check if path is a directory or secret path
-	if _, isSecret := vaultClient.ReadSecrets(rootPath, subPath); isSecret == nil {
-		isSecretPath = true
-	}
-
 	path := path.Join(rootPath, subPath)
 	if o.EnginePath != "" {
 		path = subPath
 	}
 
 	// prepare the output map
-	pathMap := utils.PathMap(path, utils.ToMapStringInterface(s), isSecretPath)
+	pathMap := utils.UnflattenMap(path, utils.ToMapStringInterface(s))
 
 	if o.EnginePath != "" {
 		return map[string]interface{}{

--- a/cmd/testdata/1.yaml
+++ b/cmd/testdata/1.yaml
@@ -1,4 +1,3 @@
 yaml/:
   secret:
     user: password
-

--- a/cmd/testdata/3.json
+++ b/cmd/testdata/3.json
@@ -1,0 +1,7 @@
+{
+  "a/b/c/": {
+    "admin": {
+      "sub": "password"
+    }
+  }
+}

--- a/cmd/testdata/secret.yaml
+++ b/cmd/testdata/secret.yaml
@@ -1,22 +1,23 @@
 {
-  "admin": {
-    "sub": "password"
-  },
-  "demo": {
-    "foo": "bar"
-  },
-  "sub/": {
-    "demo": {
-      "demo": "hello world",
-      "password": "s3cre5",
-      "user": "admin"
+  "secret/": {
+    "admin": {
+      "sub": "password"
     },
-    "sub2/": {
+    "demo": {
+      "foo": "bar"
+    },
+    "sub/": {
       "demo": {
-        "admin": "key",
-        "foo": "bar",
-        "password": "password",
-        "user": "user"
+        "demo": "hello world",
+        "password": "s3cre5<",
+        "user": "admin"
+      },
+      "sub2/": {
+        "demo": {
+          "foo": "bar",
+          "password": "password",
+          "user": "user"
+        }
       }
     }
   }

--- a/docs/export.md
+++ b/docs/export.md
@@ -3,6 +3,22 @@
 
 See the [CLI Reference](https://falcosuessgott.github.io/vkv/cmd/vkv_export/) for more details on the supported flags and env vars.
 
+!!! warning
+    Vault allows `/` in the name of a KV engine. This makes it difficult for `vkv` to distinguish between directories and the KV engine name..
+    
+    If your KV engine name/mount contains a `/` you have to specify it using `--engine-path|-e`, otherwise `vkv` will output the secrets wrong.
+
+    This also applies for any `vkv import ...` operations.
+
+!!! info
+    `vkv` handles 3 different path arguments, specified using `-e|-p`
+
+    1. `root path`: any normal KV mount. Use `-p`.
+    2. `engine-path`: in case your KV mount contains a `/`. Use `-e`.
+    3. `sub path`: the path to the corresponding directory within a KV mount. 
+    When using `-p` this is everything after the first `/`: e.g: `kv/prod/db/`; root path=`kv`, subpath=`prod/db`. 
+    In conjunction with a `-e` you can specify a sub-path by using -p: `-e=kv/prod -p=db`.
+ 
 ## base
 ```bash
 > vkv export -p secret -f=base               

--- a/docs/import.md
+++ b/docs/import.md
@@ -1,8 +1,28 @@
 # Import
 
-`vkv import` requires an engine path (`--path`) and will accepts `vkv`s YAML or JSON output (`vkv export -f=yaml|json`) either by invoking `vkv import -` (for STDIN) or by specifying a file (`--file`). `vkv` will create the specified path if the engine does not exist yet and will error if it does, unless `--force` is specified. 
+`vkv import` tries to determine the path from the input, if that is not possible you can specify on using `--path|--engine-path`. 
+
+`vkv import` accepts `vkv`s YAML or JSON output (`vkv export -f=yaml|json`) either by invoking `vkv import -` (for STDIN) or by specifying a file (`--file`). 
+
+`vkv` will create the specified path if the engine does not exist yet and will error if it does, unless `--force` is specified. 
 
 See the [CLI Reference](https://github.com/FalcoSuessgott/vkv/cmd/vkv_import/) for more details on the supported flags and env vars.
+
+!!! warning
+    Vault allows `/` in the name of KV engine. This makes it difficult for `vkv` to distinguish between directories and the KV engine name..
+    
+    If your KV engine name/mount contains a `/` you have to specify it using `--engine-path|-e`, otherwise `vkv` will output the secrets wrong.
+
+    This also applies for any `vkv import ...` operations.
+
+!!! info
+    `vkv` handles 3 different path arguments, specified using `-e|-p`
+
+    1. `root path`: any normal KV mount. Use `-p`.
+    2. `engine-path`: in case your KV mount contains a `/`. Use `-e`.
+    3. `sub path`: the path to the corresponding directory within a KV mount. 
+    When using `-p` this is everything after the first `/`: e.g: `kv/prod/db/`; root path=`kv`, subpath=`prod/db`. 
+    In conjunction with a `-e` you can specify a sub-path by using -p: `-e=kv/prod -p=db`.
 
 ## Example Usage
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/hashicorp/vault/api v1.14.0
 	github.com/juju/ansiterm v1.0.0
+	github.com/k0kubun/pp/v3 v3.2.0
 	github.com/muesli/mango-cobra v1.2.0
 	github.com/muesli/roff v0.1.0
 	github.com/savioxavier/termlink v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -440,6 +440,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/julz/importas v0.1.0 h1:F78HnrsjY3cR7j0etXy5+TU1Zuy7Xt08X/1aJnH5xXY=
 github.com/julz/importas v0.1.0/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
+github.com/k0kubun/pp/v3 v3.2.0 h1:h33hNTZ9nVFNP3u2Fsgz8JXiF5JINoZfFq4SvKJwNcs=
+github.com/k0kubun/pp/v3 v3.2.0/go.mod h1:ODtJQbQcIRfAD3N+theGCV1m/CBxweERz2dapdz1EwA=
 github.com/karamaru-alpha/copyloopvar v1.1.0 h1:x7gNyKcC2vRBO1H2Mks5u1VxQtYvFiym7fCjIP8RPos=
 github.com/karamaru-alpha/copyloopvar v1.1.0/go.mod h1:u7CIfztblY0jZLOQZgH3oYsJzpC2A7S6u/lfgSXHy0k=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/pkg/printer/secret/base.go
+++ b/pkg/printer/secret/base.go
@@ -17,12 +17,12 @@ func (p *Printer) printBase(secrets map[string]interface{}) error {
 	m := make(map[string]interface{})
 
 	for _, k := range utils.SortMapKeys(secrets) {
-		baseName := p.enginePath + utils.Delimiter
+		baseName := p.enginePath
 
 		if p.withHyperLinks {
 			addr := fmt.Sprintf("%s/ui/vault/secrets/%s/kv", p.vaultClient.Client.Address(), p.enginePath)
 
-			baseName = termlink.Link(p.enginePath+utils.Delimiter, addr, false)
+			baseName = termlink.Link(p.enginePath, addr, false)
 		}
 
 		if p.vaultClient != nil {
@@ -60,8 +60,9 @@ func (p *Printer) printTree(rootPath, subPath string, m map[string]interface{}) 
 	//nolint: nestif
 	if strings.HasSuffix(subPath, utils.Delimiter) {
 		for _, i := range utils.SortMapKeys(m) {
-			//nolint: forcetypeassert
-			tree.AddBranch(p.printTree(rootPath, subPath+i, m[i].(map[string]interface{})))
+			if data, ok := m[i].(map[string]interface{}); ok {
+				tree.AddBranch(p.printTree(rootPath, subPath+i, data))
+			}
 		}
 	} else {
 		for _, k := range utils.SortMapKeys(m) {

--- a/pkg/printer/secret/base_test.go
+++ b/pkg/printer/secret/base_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/FalcoSuessgott/vkv/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -116,14 +117,15 @@ func TestPrintBase(t *testing.T) {
 		var b bytes.Buffer
 		tc.opts = append(tc.opts,
 			WithWriter(&b),
-			WithEnginePath(tc.rootPath),
+			WithEnginePath(utils.NormalizePath(tc.rootPath)),
 		)
 
 		p := NewSecretPrinter(tc.opts...)
 
-		m := map[string]interface{}{}
+		m := map[string]interface{}{
+			utils.NormalizePath(tc.rootPath): tc.s,
+		}
 
-		m[tc.rootPath+"/"] = tc.s
 		require.NoError(t, p.Out(m))
 		assert.Equal(t, tc.output, b.String(), tc.name)
 	}

--- a/pkg/printer/secret/secret_printer.go
+++ b/pkg/printer/secret/secret_printer.go
@@ -79,9 +79,7 @@ func CustomValueLength(length int) Option {
 // OnlyKeys flag for only showing secrets keys.
 func OnlyKeys(b bool) Option {
 	return func(p *Printer) {
-		if b {
-			p.onlyKeys = true
-		}
+		p.onlyKeys = b
 	}
 }
 
@@ -97,9 +95,7 @@ func WithHyperLinks(b bool) Option {
 // OnlyPaths flag for only printing kv paths.
 func OnlyPaths(b bool) Option {
 	return func(p *Printer) {
-		if b {
-			p.onlyPaths = true
-		}
+		p.onlyPaths = b
 	}
 }
 
@@ -117,30 +113,24 @@ func WithWriter(w io.Writer) Option {
 	}
 }
 
-// ShowValues flag for unmasking secrets in output.
+// ShowValues flag for displaying the secrets version.
 func ShowValues(b bool) Option {
 	return func(p *Printer) {
-		if b {
-			p.showValues = true
-		}
+		p.showValues = b
 	}
 }
 
 // ShowVersion flag for unmasking secrets in output.
 func ShowVersion(b bool) Option {
 	return func(p *Printer) {
-		if b {
-			p.showVersion = true
-		}
+		p.showVersion = b
 	}
 }
 
 // ShowMetadata flag for unmasking secrets in output.
 func ShowMetadata(b bool) Option {
 	return func(p *Printer) {
-		if b {
-			p.showMetadata = true
-		}
+		p.showMetadata = b
 	}
 }
 
@@ -191,6 +181,13 @@ func NewSecretPrinter(opts ...Option) *Printer {
 	}
 
 	return p
+}
+
+// Update update printer applies the given options.
+func Update(p *Printer, opts ...Option) {
+	for _, opt := range opts {
+		opt(p)
+	}
 }
 
 // Out prints out the secrets according all configured options.

--- a/pkg/printer/secret/yaml.go
+++ b/pkg/printer/secret/yaml.go
@@ -12,7 +12,7 @@ func (p *Printer) printYAML(secrets map[string]interface{}) error {
 		return err
 	}
 
-	fmt.Fprintln(p.writer, string(out))
+	fmt.Fprint(p.writer, string(out))
 
 	return nil
 }

--- a/pkg/printer/secret/yaml_test.go
+++ b/pkg/printer/secret/yaml_test.go
@@ -35,7 +35,6 @@ func TestPrintYAML(t *testing.T) {
   secret:
     key: value
     user: password
-
 `,
 		},
 		{
@@ -55,7 +54,6 @@ func TestPrintYAML(t *testing.T) {
   secret:
     key: ""
     user: ""
-
 `,
 		},
 	}

--- a/scripts/prepare-vault.sh
+++ b/scripts/prepare-vault.sh
@@ -19,3 +19,14 @@ vault kv put secret_2/demo foo=bar
 vault kv put secret_2/admin sub=password
 vault kv put secret_2/sub/demo demo="hello world" user=admin password='s3cre5<'
 vault kv put secret_2/sub/sub2/demo foo=bar-updated user=user password=password
+
+
+# # test cases
+# 1. rootpath -> rootpath
+# 2. subpath -> rootpath
+# 3. subpath -> subpath
+# 4. root path -> enginepath
+# 5. enginepath -> enginepath
+# 6. engie path + sub > engine path + sub
+# 7. engine path -> root path
+# 8. engine path -> subpath


### PR DESCRIPTION
fixes #276 based on #277.

- [x] detect the engine path from the input if possible
- [x] support `-e` in `vkv import`
- [x] correctly append `-p` when using `-e`.
- [x] docs
- [x] test suite (see below)

# test cases
- [x] secrets imported, exported from original path
- [x] secrets imported with overwritten path, exported from overwritten path
- [x] import secrets, overwrite path with engine path, export from engine path
- [x] import secrets, overwrite path with engine path and subpath, export from engine path
- [x] import secrets, overwrite path and subpath, read from path