### PR TITLE
fix(token): implement vault token precendence logic

### DIFF
--- a/.golang-ci.yml
+++ b/.golang-ci.yml
@@ -28,3 +28,6 @@ linters:
     - revive
     - depguard
     - tagalign
+    - copyloopvar
+    - intrange
+    - execinquery

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -118,7 +118,7 @@ func (s *VaultSuite) TestMode() {
 
 func TestVaultSuite(t *testing.T) {
 	// github actions doesn't offer the docker socket, which we need to run this test suite
-	if runtime.GOOS == "linux" {
+	if runtime.GOOS != "windows" {
 		suite.Run(t, new(VaultSuite))
 	}
 }

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -2,7 +2,7 @@
 
 `vkv` supports all of Vaults [environment variables](https://www.vaultproject.io/docs/commands#environment-variables) as well as any configured [Token helpers](https://developer.hashicorp.com/vault/docs/commands/token-helper). 
 
-In order to authenticate you will have to set at least `VAULT_ADDR` and `VAULT_TOKEN`.
+In order to authenticate you will have to set at least one of the `VAULT_ADDR` or `VKV_LOGIN_COMMAND` and `VAULT_TOKEN` env vars.
 
 ## MacOS/Linux
 ```
@@ -20,7 +20,7 @@ vkv.exe export --path <KVv2-path>
 
 ## Special Env Var `VKV_LOGIN_COMMAND`
 For advanced use cases, you can set `VKV_LOGIN_COMMAND`, that way `vkv` will first execute the specified command and use the output of the command as the token.
-This is way you dont have to hardcode and set `VAULT_TOKEN`, this is especially useful when using `vkv` in CI. (See Gitlab Integration):
+This is way you don't have to hardcode and set `VAULT_TOKEN`, this is especially useful when using `vkv` in CI. (See Gitlab Integration):
 
 Example:
 
@@ -28,3 +28,25 @@ Example:
 export VKV_LOGIN_COMMAND="vault write -field=token auth/jwt/login jwt=${CI_JOB_JWT_V2}"
 vkv export -p
 ```
+
+## Token Precedence
+The following token precedence is applied (from highest to lowest):
+
+1. `VKV_TOKEN`
+2. `VKV_LOGIN_COMMAND`
+3. [Vault Token Helper](https://developer.hashicorp.com/vault/docs/commands/token-helper), where the token will be written to `~/.vault-token`.
+
+If `vkv` detects **more than one possible token source**, warnings are shown as the following, indicating which token source will be used:
+
+```bash
+$> vkv export -p secret
+[WARN] More than one token source configured (either VAULT_TOKEN, VKV_LOGIN_COMMAND or ~/.vault-token).
+[WARN] See https://falcosuessgott.github.io/vkv/authentication/#token-precedence for vkv's token precedence logic. Disable these warnings with VKV_DISABLE_WARNING.
+[INFO] Using VAULT_TOKEN.
+
+secret/ [desc=key/value secret storage] [type=kv2]
+└── secret [v=1]
+    └── key=*****
+```
+
+As described, one can disable these warning by setting `VKV_DISABLE_WARNING` to any value.

--- a/pkg/testutils/testutils_test.go
+++ b/pkg/testutils/testutils_test.go
@@ -52,7 +52,7 @@ func (s *VaultSuite) TestVaultConnection() {
 
 func TestVaultSuite(t *testing.T) {
 	// github actions doesn't offer the docker socket, which we need to run this test suite
-	if runtime.GOOS == "linux" {
+	if runtime.GOOS != "windows" {
 		suite.Run(t, new(VaultSuite))
 	}
 }

--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -18,45 +18,18 @@ type Vault struct {
 
 // NewDefaultClient returns a new vault client wrapper.
 func NewDefaultClient() (*Vault, error) {
+	token, err := getToken()
+	if err != nil {
+		return nil, err
+	}
+
 	// create vault client using defaults (recommended)
 	c, err := api.NewClient(nil)
 	if err != nil {
 		return nil, err
 	}
 
-	// use tokenhelper if available
-	th, err := tokenhelper.NewInternalTokenHelper()
-	if err != nil {
-		return nil, fmt.Errorf("error creating default token helper: %w", err)
-	}
-
-	token, err := th.Get()
-	if err != nil {
-		return nil, fmt.Errorf("error getting token from default token helper: %w", err)
-	}
-
-	if token != "" {
-		c.SetToken(token)
-	}
-
-	// custom: if VKV_LOGIN_COMMAND is set, execute it and set the output as token
-	cmd, ok := os.LookupEnv("VKV_LOGIN_COMMAND")
-	if ok && cmd != "" {
-		cmdParts := strings.Split(cmd, " ")
-
-		token, err := exec.Run(cmdParts)
-		if err != nil {
-			return nil, fmt.Errorf("error running VKV_LOGIN_CMD (%s): %w", cmd, err)
-		}
-
-		vaultToken := strings.TrimSpace(string(token))
-		if vaultToken == "" {
-			return nil, errors.New("VKV_LOGIN_COMMAND required but not set")
-		}
-
-		// set token
-		c.SetToken(vaultToken)
-	}
+	c.SetToken(token)
 
 	// self lookup current auth for verification
 	if _, err := c.Auth().Token().LookupSelf(); err != nil {
@@ -80,4 +53,103 @@ func NewClient(addr, token string) (*Vault, error) {
 	c.SetToken(token)
 
 	return &Vault{Client: c}, nil
+}
+
+// getToken finds the token configured by the user via env vars or token helpers
+// Precedence: 1. VAULT_TOKEN, 2. VKV_LOGIN_COMMAND, 3. Vault Token Helper.
+//
+//nolint:cyclop
+func getToken() (string, error) {
+	// warn user if more than one is configured
+	envToken, envTokenOk := os.LookupEnv("VAULT_TOKEN")
+	tokenCommand, tokenCommandOk := os.LookupEnv("VKV_LOGIN_COMMAND")
+
+	th, err := tokenhelper.NewInternalTokenHelper()
+	if err != nil {
+		return "", fmt.Errorf("error creating default token helper: %w", err)
+	}
+
+	thToken, err := th.Get()
+	if err != nil {
+		return "", fmt.Errorf("error getting token from default token helper: %w", err)
+	}
+
+	var (
+		// number of tokens configured
+		tokenSources int
+
+		// if we issue a warning to the user, we also want to inform with what token option we went
+		warn bool
+	)
+
+	if envTokenOk {
+		tokenSources++
+	}
+
+	if tokenCommandOk {
+		tokenSources++
+	}
+
+	if thToken != "" {
+		tokenSources++
+	}
+
+	// check whether user disabled warnings
+	_, disableWarn := os.LookupEnv("VKV_DISABLE_WARNING")
+
+	if tokenSources > 1 {
+		warn = true
+
+		if !disableWarn {
+			fmt.Println("[WARN] More than one token source configured (either VAULT_TOKEN, VKV_LOGIN_COMMAND or ~/.vault-token).")
+			fmt.Println("[WARN] See https://falcosuessgott.github.io/vkv/authentication/token-precedence for vkv's token precedence logic. Disable these warnings with VKV_DISABLE_WARNING.")
+		}
+	}
+
+	// if VAULT_TOKEN is set - return it
+	if envToken != "" {
+		if warn && !disableWarn {
+			fmt.Println("[INFO] Using VAULT_TOKEN.")
+			fmt.Println()
+		}
+
+		return envToken, nil
+	}
+
+	// if VKV_LOGIN_COMMAND
+	if tokenCommand != "" {
+		if warn && !disableWarn {
+			fmt.Println("[INFO] Using VKV_LOGIN_COMMAND.")
+			fmt.Println()
+		}
+
+		return runVaultTokenCommand(tokenCommand)
+	}
+
+	if thToken != "" {
+		if warn && !disableWarn {
+			fmt.Println("[INFO] Using ~/.vault-token.")
+			fmt.Println()
+		}
+
+		return thToken, nil
+	}
+
+	return "", errors.New("no token provided")
+}
+
+func runVaultTokenCommand(cmd string) (string, error) {
+	cmdParts := strings.Split(cmd, " ")
+
+	token, err := exec.Run(cmdParts)
+	if err != nil {
+		return "", fmt.Errorf("error running VKV_LOGIN_CMD (%s): %w", cmd, err)
+	}
+
+	vaultToken := strings.TrimSpace(string(token))
+	if vaultToken == "" {
+		return "", errors.New("VKV_LOGIN_COMMAND required but not set")
+	}
+
+	return vaultToken, nil
 }


### PR DESCRIPTION
The following token precedence is applied (from highest to lowest):

1. `VKV_TOKEN`
2. `VKV_LOGIN_COMMAND`
3. [Vault Token Helper](https://developer.hashicorp.com/vault/docs/commands/token-helper), where the token will be written to `~/.vault-token`.

If `vkv` detects **more than one possible token source**, warnings are shown as the following, indicating which token source will be used:

```bash
$> vkv export -p secret
[WARN] More than one token source configured (either VAULT_TOKEN, VKV_LOGIN_COMMAND or ~/.vault-token).
[WARN] See https://falcosuessgott.github.io/vkv/authentication/#token-precedence for vkv's token precedence logic. Disable these warnings with VKV_DISABLE_WARNING.
[INFO] Using VAULT_TOKEN.

secret/ [desc=key/value secret storage] [type=kv2]
└── secret [v=1]
    └── key=*****
```

As described, one can disable these warning by setting `VKV_DISABLE_WARNING` to any value.


fixes #305.