### PR TITLE
support legacy kv engine of type generic

### DIFF
--- a/pkg/vault/engine.go
+++ b/pkg/vault/engine.go
@@ -49,6 +49,12 @@ func (v *Vault) GetEngineTypeVersion(rootPath string) (string, string, error) {
 			eType = t.(string)
 		}
 
+		// "options" is nil in "generic" type
+		//nolint: goconst
+		if eType == "generic" {
+			return "kv", "1", nil
+		}
+
 		v, ok := data.Data["options"]
 		if ok {
 			//nolint: forcetypeassert


### PR DESCRIPTION
engine type error was partly fixed with issue #232  but still remains a problem with export.

```
vkv export -p generic_se/path
panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 1 [running]:
github.com/FalcoSuessgott/vkv/pkg/vault.(*Vault).GetEngineTypeVersion(0xc000354948?, {0xc000354948, 0x3})
	/home/runner/work/vkv/vkv/pkg/vault/engine.go:55 +0x228
github.com/FalcoSuessgott/vkv/pkg/printer/secret.(*Printer).printBase(0xc0003da0a0, 0xc0004d8b70?)
	/home/runner/work/vkv/vkv/pkg/printer/secret/base.go:36 +0x377
github.com/FalcoSuessgott/vkv/pkg/printer/secret.(*Printer).Out(0xc0003da0a0, {0xae16a0?, 0xc0004d87b0?})
	/home/runner/work/vkv/vkv/pkg/printer/secret/secret_printer.go:224 +0x2ac
github.com/FalcoSuessgott/vkv/cmd.NewExportCmd.func1(0xc0004b6200?, {0xc00061f460?, 0x4?, 0xb99cfc?})
	/home/runner/work/vkv/vkv/cmd/export.go:84 +0x594
github.com/spf13/cobra.(*Command).execute(0xc0004a7b00, {0xc00061f440, 0x2, 0x2})
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xabc
github.com/spf13/cobra.(*Command).ExecuteC(0xc0004a7800)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/FalcoSuessgott/vkv/cmd.Execute()
	/home/runner/work/vkv/vkv/cmd/root.go:117 +0x18
main.main()
	/home/runner/work/vkv/vkv/main.go:15 +0x4f
```

With the fix:

```
vkv export -p generic_se/path
generic_se/ [type=kv1]
└── path
...
```        

