### PR TITLE
Improve KV engine v1 detection

### DIFF
--- a/pkg/vault/kv.go
+++ b/pkg/vault/kv.go
@@ -128,6 +128,9 @@ func (v *Vault) IsKVv1(ctx context.Context, rootPath string) (bool, error) {
 		if opts["version"].(string) == "1" {
 			return true, nil
 		}
+	} else {
+		// When options is nil, assume it's a V1 engine
+		return true, nil
 	}
 
 	return false, nil


### PR DESCRIPTION
Hello

The `IsKVv1` function calls the `sys/internal/ui/mounts/mysecretengine` API path to determine the engine version.

When a version 1 engine is mounted as `kv` type and not `kv-v1`, the `options` field is not set as seen here: https://github.com/hashicorp/vault/blob/v1.21.4/vault/logical_system.go#L1615 and VKV fails.

Vault itself assumes that an unspecified version is a version 1: https://github.com/hashicorp/vault/blob/v1.21.4/vault/mount.go#L1814-L1816

This patch makes the same assumption and restores functionality for version 1 KV engine.